### PR TITLE
This simplifies getSingleWoeid method

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -8,5 +8,5 @@ console.log(getSingleWOEID('india'));
 
 console.log(getSingleWOEID('chicago'));
 
-const [{ woeid }] = getSingleWOEID('chennai');
+const { woeid } = getSingleWOEID('chennai');
 console.log(`* See the demo.js/readme *\nWOEID of Chennai: ${woeid}`);

--- a/index.js
+++ b/index.js
@@ -3,9 +3,10 @@ const data = require('./data');
 // console.log(data.length);
 // console.log([...new Set(data.map(({ name }) => name))].length);
 
-const getSingleWOEID = cityName =>
-  data.filter(i => i.name.toLowerCase() === cityName.toLowerCase());
-
+const getSingleWOEID = cityName => {
+  let woeidData = data.filter(i => i.name.toLowerCase() === cityName.toLowerCase());
+  return woeidData[0];
+};
 const getAllWOEID = countryName =>
   data.filter(i => i.country.toLowerCase() === countryName.toLowerCase());
 

--- a/readme.md
+++ b/readme.md
@@ -14,21 +14,17 @@ This NPM module offers methods to get WOEID of all locations that Twitter has tr
 
 ## Available Methods
 
+Use this method for getting the WOEID of a City (Local Trends) or a Country (National Trends).
+
 ```JS
 getSingleWOEID(cityName)
 ```
 
-Use the above method for getting the WOEID of a City (Local Trends).
-
-Use the above method for getting the WOEID of a Country (National Trends).
+Use the this method for getting the WOEIDs of all cities (that Twitter has trending topic information for) of that country.
 
 ```JS
 getAllWOEID(countryName)
 ```
-
-Use the above method for getting the WOEIDs of all cities (that Twitter has trending topic information for) of that country.
-
-Each of the above methods returns an array of matching city/country.
 
 ## Example
 
@@ -39,7 +35,7 @@ console.log(getSingleWOEID('new york'));
 
 // RETURNS
 
-[{ name: 'New York', country: 'United States', woeid: 2459115 }];
+{ name: 'New York', country: 'United States', woeid: 2459115 };
 ```
 
 #### Country
@@ -49,7 +45,7 @@ console.log(getSingleWOEID('india'));
 
 // RETURNS
 
-[{ name: 'India', country: 'India', woeid: 23424848 }];
+{ name: 'India', country: 'India', woeid: 23424848 };
 ```
 
 #### All (Available) cities of a Country
@@ -72,7 +68,7 @@ console.log(getAllWOEID('japan'));
 Using destructuring
 
 ```JS
-const [{ woeid }] = getSingleWOEID('chennai');
+const { woeid } = getSingleWOEID('chennai');
 
 twit.get('trends/place', { id: woeid })
   .then(res => console.log(res.data[0]))


### PR DESCRIPTION
getSIngleWoeid returns a list of arrays, but will **always return only one**, so the user has to unnecessarily type [0] after this function. My suggestion is to already return that array.

Before:
```JS
getSingleWoeid('Brazil')[0].woeid;
```

After:
```JS
getSingleWoeid('Brazil').woeid;
```

Before with destructuring: 
```JS
const [{ woeid }] = getSingleWOEID('chennai');
```

After with desctructuring: 
```JS
const { woeid } = getSingleWOEID('chennai');
```

Also, adjust the explanations in demo and readme.md